### PR TITLE
Add support for HTTP proxy

### DIFF
--- a/dapp_runner/_util.py
+++ b/dapp_runner/_util.py
@@ -10,7 +10,7 @@ def get_free_port(range_start: int = 8080, range_end: int = 9090) -> int:
     """Get the first available port on localhost within the specified range.
 
     The range is inclusive on both sides (i.e. `range_end` will be included).
-    Raises `OverflowError` when no free port could be found.
+    Raises `RuntimeError` when no free port could be found.
     """
     for port in range(range_start, range_end + 1):
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
@@ -18,7 +18,7 @@ def get_free_port(range_start: int = 8080, range_end: int = 9090) -> int:
             if response == 0:
                 return port
 
-    raise OverflowError(
+    raise RuntimeError(
         f"No free ports found. range_start={range_start}, range_end={range_end}"
     )
 

--- a/dapp_runner/_util.py
+++ b/dapp_runner/_util.py
@@ -1,6 +1,26 @@
 from datetime import datetime, timezone
+import socket
+
 from yapapi import Golem, __version__ as yapapi_version
+
 from colors import yellow
+
+
+def get_free_port(range_start: int = 8080, range_end: int = 9090) -> int:
+    """Get the first available port on localhost within the specified range.
+
+    The range is inclusive on both sides (i.e. `range_end` will be included).
+    Raises `OverflowError` when no free port could be found.
+    """
+    for port in range(range_start, range_end + 1):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            response = s.connect_ex(("localhost", port))
+            if response == 0:
+                return port
+
+    raise OverflowError(
+        f"No free ports found. range_start={range_start}, range_end={range_end}"
+    )
 
 
 def _print_env_info(golem: Golem):

--- a/dapp_runner/runner/runner.py
+++ b/dapp_runner/runner/runner.py
@@ -9,7 +9,8 @@ from yapapi.contrib.service.http_proxy import LocalHttpProxy
 from yapapi.events import CommandExecuted
 from yapapi.network import Network
 from yapapi.payload import Payload
-from yapapi.services import Cluster, ServiceState
+from yapapi.services.cluster import Cluster
+from yapapi.services.service_state import ServiceState
 
 from dapp_runner.descriptor import Config, DappDescriptor
 from dapp_runner.descriptor.dapp import PortMapping
@@ -17,6 +18,8 @@ from dapp_runner._util import get_free_port
 
 from .payload import get_payload
 from .service import get_service, DappService
+
+LOCAL_PROXY_DATA_KEY = "local_proxy_address"
 
 
 class Runner:
@@ -77,7 +80,7 @@ class Runner:
 
         self._proxies[name] = proxy
         self.data_queue.put_nowait(
-            {name: {"local_proxy_address": f"http://localhost:{port}"}}
+            {name: {LOCAL_PROXY_DATA_KEY: f"http://localhost:{port}"}}
         )
 
     async def start(self):

--- a/dapp_runner/runner/runner.py
+++ b/dapp_runner/runner/runner.py
@@ -13,6 +13,7 @@ from yapapi.services import Cluster, ServiceState
 
 from dapp_runner.descriptor import Config, DappDescriptor
 from dapp_runner.descriptor.dapp import PortMapping
+from dapp_runner._util import get_free_port
 
 from .payload import get_payload
 from .service import get_service, DappService
@@ -70,7 +71,7 @@ class Runner:
     async def _start_local_proxy(
         self, name: str, cluster: Cluster, port_mapping: PortMapping
     ):
-        port = port_mapping.local_port or 8080
+        port = port_mapping.local_port or get_free_port()
         proxy = LocalHttpProxy(cluster, port)
         await proxy.run()
         self._proxies[name] = proxy

--- a/dapp_runner/runner/runner.py
+++ b/dapp_runner/runner/runner.py
@@ -74,7 +74,11 @@ class Runner:
         port = port_mapping.local_port or get_free_port()
         proxy = LocalHttpProxy(cluster, port)
         await proxy.run()
+
         self._proxies[name] = proxy
+        self.data_queue.put_nowait(
+            {name: {"local_proxy_address": f"http://localhost:{port}"}}
+        )
 
     async def start(self):
         """Start the Golem engine and the dapp."""

--- a/dapp_runner/runner/runner.py
+++ b/dapp_runner/runner/runner.py
@@ -213,6 +213,9 @@ class Runner:
         """Stop the dapp and the Golem engine."""
         service_tasks: List[asyncio.Task] = []
 
+        proxies = self._proxies.values()
+        await asyncio.gather(*[p.stop() for p in proxies])
+
         for cluster in self.clusters.values():
             cluster.stop()
 
@@ -221,8 +224,6 @@ class Runner:
 
         networks = self._networks.values()
         await asyncio.gather(*[n.remove() for n in networks])
-        proxies = self._proxies.values()
-        await asyncio.gather(*[p.stop() for p in proxies])
 
         await self.golem.stop()
 

--- a/dapp_runner/runner/runner.py
+++ b/dapp_runner/runner/runner.py
@@ -63,10 +63,10 @@ class Runner:
         await self._load_payloads()
 
         for service_name, service_descriptor in self.dapp.nodes.items():
-            cluster_class = await get_service(
+            cluster_class, run_params = await get_service(
                 service_name, service_descriptor, self._payloads
             )
-            cluster = await self.start_cluster(service_name, cluster_class)
+            cluster = await self.start_cluster(service_name, cluster_class, run_params)
 
             # launch queue listeners for all the service instances
             for idx in range(len(cluster.instances)):
@@ -80,9 +80,9 @@ class Runner:
                     ]
                 )
 
-    async def start_cluster(self, cluster_name, cluster_class):
+    async def start_cluster(self, cluster_name, cluster_class, run_params):
         """Start a single cluster for this dapp."""
-        cluster = await self.golem.run_service(cluster_class)
+        cluster = await self.golem.run_service(cluster_class, **run_params)
         self.clusters[cluster_name] = cluster
         return cluster
 

--- a/dapp_runner/runner/service.py
+++ b/dapp_runner/runner/service.py
@@ -112,6 +112,11 @@ async def get_service(
     )
 
     if desc.http_proxy:
+        if len(desc.http_proxy.ports) > 1:
+            raise NotImplementedError(
+                "Multiple port mappings are not currently supported."
+            )
+
         port_mapping = desc.http_proxy.ports[0]
         service_instance_params["remote_port"] = port_mapping.remote_port
         DappServiceClass = type(

--- a/dapp_runner/runner/service.py
+++ b/dapp_runner/runner/service.py
@@ -4,6 +4,7 @@ from typing import Dict, List, Tuple, Type, Optional
 
 
 from yapapi.contrib.service.http_proxy import HttpProxyService
+from yapapi.network import Network
 from yapapi.payload import Payload
 from yapapi.services import Service, ServiceState
 
@@ -89,7 +90,10 @@ class HttpProxyDappService(DappService, HttpProxyService):
 
 
 async def get_service(
-    name: str, desc: ServiceDescriptor, payloads: Dict[str, Payload]
+    name: str,
+    desc: ServiceDescriptor,
+    payloads: Dict[str, Payload],
+    networks: Dict[str, Network],
 ) -> Tuple[Type[Service], dict]:
     """Create a service class corresponding with its descriptor."""
 
@@ -119,5 +123,7 @@ async def get_service(
     run_service_kwargs: dict = {}
     run_service_kwargs["payload"] = payload_instance
     run_service_kwargs["instance_params"] = [service_instance_params]
+    if desc.network:
+        run_service_kwargs["network"] = networks[desc.network]
 
     return DappServiceClass, run_service_kwargs

--- a/examples/yagna-config-template.yaml
+++ b/examples/yagna-config-template.yaml
@@ -1,0 +1,7 @@
+yagna:
+  subnet_tag: null
+  app_key: "ec40b0afe9f640558bd087c43ca31f78"
+payment:
+  budget: 1.0
+  driver: "zksync"
+  network: "rinkeby"

--- a/examples/yagna-config-template.yaml
+++ b/examples/yagna-config-template.yaml
@@ -1,7 +1,0 @@
-yagna:
-  subnet_tag: null
-  app_key: "ec40b0afe9f640558bd087c43ca31f78"
-payment:
-  budget: 1.0
-  driver: "zksync"
-  network: "rinkeby"

--- a/tests/unit/runner/test_service.py
+++ b/tests/unit/runner/test_service.py
@@ -7,7 +7,7 @@ from unittest.mock import Mock
 from yapapi.ctx import WorkContext, Script
 from yapapi.script import Run
 
-from dapp_runner.runner.service import DappService
+from dapp_runner.runner.service import DappService, HttpProxyDappService
 
 
 @pytest.fixture
@@ -36,9 +36,8 @@ def mock_work_context():  # noqa
 )
 async def test_service_entrypoint(mock_work_context, entrypoint, expected_script):
     """Test if the DappService's entrypoint works as expected."""
-    service = DappService()
+    service = DappService(entrypoint)
     service._ctx = mock_work_context
-    service.entrypoint = entrypoint
     scripts = []
     gen = service.start()
 
@@ -65,3 +64,58 @@ async def test_service_entrypoint(mock_work_context, entrypoint, expected_script
         assert (
             entrypoint_script._commands[i].evaluate() == expected_script[i].evaluate()
         )
+
+
+@pytest.mark.parametrize(
+    "service_kwargs, expected_attrs, expected_exc",
+    [
+        (
+            {"entrypoint": ["/some/binary"]},
+            {
+                "entrypoint": ["/some/binary"],
+                "_remote_port": 80,
+                "_remote_host": None,
+                "_remote_response_timeout": 10.0,
+            },
+            None,
+        ),
+        (
+            {
+                "entrypoint": ["/some/binary"],
+                "remote_port": 666,
+                "remote_host": "imahost",
+                "response_timeout": 66.6,
+            },
+            {
+                "entrypoint": ["/some/binary"],
+                "_remote_port": 666,
+                "_remote_host": "imahost",
+                "_remote_response_timeout": 66.6,
+            },
+            None,
+        ),
+        (
+            {
+                "remote_port": 666,
+            },
+            {},
+            TypeError(
+                "__init__() missing 1 required positional argument: 'entrypoint'"
+            ),
+        ),
+        (
+            {"entrypoint": ["/some/binary"], "unknown_kwarg": "im-invalid"},
+            {},
+            TypeError("__init__() got an unexpected keyword argument 'unknown_kwarg'"),
+        ),
+    ],
+)
+def test_proxy_dapp_service(test_utils, service_kwargs, expected_attrs, expected_exc):
+    """Test if HttpProxyDappService has its inherited fields initialized correctly."""
+    try:
+        proxy_service = HttpProxyDappService(**service_kwargs)
+
+        for name, value in expected_attrs.items():
+            assert getattr(proxy_service, name) == value
+    except Exception as e:
+        test_utils.verify_error(expected_exc, e)

--- a/tests/unit/util/util.py
+++ b/tests/unit/util/util.py
@@ -1,0 +1,21 @@
+"""Unit tests for dapp_runner._util."""
+from unittest import mock
+
+from dapp_runner._util import get_free_port
+
+
+@mock.patch("socket.socket.connect_ex", mock.Mock(side_effect=[1, 0]))
+def test_get_free_port_available():
+    """Test if the first available port is correctly returned."""
+    assert get_free_port() == 8081
+
+
+@mock.patch("socket.socket.connect_ex", mock.Mock(return_value=1))
+def test_get_free_port_exceeded(test_utils):
+    """Test if the expected error is raised when no free port was found."""
+    try:
+        get_free_port()
+    except Exception as e:
+        test_utils.verify_error(
+            OverflowError("No free ports found. range_start=8080, range_end=9090"), e
+        )

--- a/tests/unit/util/util.py
+++ b/tests/unit/util/util.py
@@ -17,5 +17,5 @@ def test_get_free_port_exceeded(test_utils):
         get_free_port()
     except Exception as e:
         test_utils.verify_error(
-            OverflowError("No free ports found. range_start=8080, range_end=9090"), e
+            RuntimeError("No free ports found. range_start=8080, range_end=9090"), e
         )


### PR DESCRIPTION
Resolves #13 
Resolves #18 

This adds support for creating HTTP proxies between local ports on the requestor and remote ports on the providers.

Key changes:
- `Runner#start` now creates VPNs based on the YAML descriptor file (including the implicit `default` network) - this resolves #18 
- `Runner#start` also sets up both local and remote proxies based on the `http_proxy` descriptor from nodes defined in the YAML descriptor file
- the signature of `service#get_service` has changed: it now returns a kwargs dict for `Golem#run_service` along with the service class that should be instantiated

The address of each local proxy is pushed to the runner's `data` stream, the message has the following format:
```
{"http": {"local_proxy_address": "http://localhost:8080"}}
```
The top-level key (in this case `http`) is the name of the service/cluster.