### PR TITLE
update the `dapp-store` repository path

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "dapp-store"]
 	path = dapp-store
-	url = git@github.com:golemfactory/dapp-store.git
+	url = https://github.com/golemfactory/dapp-store.git


### PR DESCRIPTION
make the path point to `https` so that it doesn't require a log-in