### PR TITLE
Blue/explicit run in init

### DIFF
--- a/dapp_runner/descriptor/base.py
+++ b/dapp_runner/descriptor/base.py
@@ -76,7 +76,11 @@ class BaseDescriptor(Generic[DescriptorType]):
 
     @classmethod
     def _resolve_field(cls, f: Field, descriptor_value: Any, field_type=None):
-        if not field_type:
+        # field has a load function defined, so we're delegating the responsibility
+        if f.metadata.get("load"):
+            return f.metadata["load"](descriptor_value)
+
+        elif not field_type:
             field_type = f.type
 
         # field is a simple type (i.e. not a `typing` type hint)

--- a/dapp_runner/descriptor/dapp.py
+++ b/dapp_runner/descriptor/dapp.py
@@ -109,16 +109,16 @@ class ServiceDescriptor(BaseDescriptor["ServiceDescriptor"]):
 
     def __validate_entrypoint(self):
         if self.entrypoint:
-            if self.init:
-                raise DescriptorError(
-                    "Cannot specify both `init` and `entrypoint`. "
-                    "Please use `init` only."
-                )
             warnings.warn(
                 f"`{type(self).__name__}.entrypoint` is deprecated. "
                 f"Please use `init` instead.",
                 DeprecationWarning,
             )
+            if self.init:
+                raise DescriptorError(
+                    "Cannot specify both `init` and `entrypoint`. "
+                    "Please use `init` only."
+                )
             if isinstance(self.entrypoint[0], str):
                 self.entrypoint = [self.entrypoint]  # noqa
             for c in self.entrypoint:

--- a/dapp_runner/descriptor/dapp.py
+++ b/dapp_runner/descriptor/dapp.py
@@ -51,7 +51,7 @@ class HttpProxyDescriptor(BaseDescriptor["HttpProxyDescriptor"]):
 class CommandDescriptor:
     """Exeunit command descriptor."""
 
-    cmd: str
+    cmd: str = EXEUNIT_CMD_RUN
     params: Dict[str, Any] = field(default_factory=dict)
 
 
@@ -61,9 +61,7 @@ class _CommandDescriptorList:
     def _process_command(self, c):
         if isinstance(c, list):
             # assuming it's a `run`
-            self.commands.append(
-                CommandDescriptor(cmd=EXEUNIT_CMD_RUN, params={"args": c})
-            )
+            self.commands.append(CommandDescriptor(params={"args": c}))
         elif isinstance(c, dict):
             for cmd, params in c.items():
                 if cmd == EXEUNIT_CMD_RUN and isinstance(params, list):
@@ -125,6 +123,7 @@ class ServiceDescriptor(BaseDescriptor["ServiceDescriptor"]):
                 self.init.append(
                     CommandDescriptor(cmd=EXEUNIT_CMD_RUN, params={"args": c})
                 )
+        # ensure it's not used anymore
         self.entrypoint = []
 
     def __post_init__(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,9 @@ all_checks = ["code_check", "code_format", "code_typing"]
 unit_test = "pytest --cov --cov-report html --cov-report term -sv tests/unit"
 test = ["unit_test", "all_checks"]
 
+[tool.pytest.ini_options]
+asyncio_mode= "auto"
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/tests/unit/descriptor/test_dapp.py
+++ b/tests/unit/descriptor/test_dapp.py
@@ -315,6 +315,17 @@ def test_http_proxy_descriptor(
             ],
             None,
         ),
+        # ensure the shorthand `run` form 2 syntax works correctly
+        (
+            {
+                "payload": "foo",
+                "init": [{"run": ["test", "blah"]}],
+            },
+            [
+                CommandDescriptor("run", {"args": ["test", "blah"]}),
+            ],
+            None,
+        ),
         # two commands in one dict (accidental user's mistake)
         (
             {


### PR DESCRIPTION
closes #17 
closes #16 


this is the implemented syntax as per: https://github.com/golemfactory/golem-architecture/pull/39#issuecomment-1245416018

```
    init:
      - test:
          args: ["/bin/rm", "/var/log/nginx/access.log", "/var/log/nginx/error.log"]
          from: "aa"
          to: "b"
      - aaa:
          args: ["/bin/rm", "/var/log/nginx/access.log", "/var/log/nginx/error.log"]
          from: "aa"
          to: "b"

    init: ["/docker-entrypoint.sh"]

    init:
      - run:
          args:
            - "/docker-entrypoint.sh"
 
    init:
        - ["/docker-entrypoint.sh"]
        - ["/bin/chmod", "a+x", "/"]
        - ["/bin/sh", "-c", 'echo "Hello from inside Golem!" > /usr/share/nginx/html/index.html']
```

and obviously, currently the only supported command is `run`