### PR TITLE
Added "timestamp" and "app" fields in state stream

### DIFF
--- a/dapp_runner/__main__.py
+++ b/dapp_runner/__main__.py
@@ -112,7 +112,7 @@ def start(
 
     # TODO: perhaps include some name from the descriptor in the run ID?
     prefix = shortuuid.ShortUUID().random(length=6)
-    start_time = datetime.now().strftime("%Y%m%d_%H:%M:%S%z")
+    start_time = datetime.now().strftime("%Y%m%d_%H_%M_%S%z")
     run_id = f"{prefix}_{start_time}"
     app_dir = _get_run_dir(run_id)
 

--- a/dapp_runner/_util.py
+++ b/dapp_runner/_util.py
@@ -1,6 +1,8 @@
 from datetime import datetime, timezone
 import socket
+from typing import Any
 
+import statemachine
 from yapapi import Golem, __version__ as yapapi_version
 
 from colors import yellow
@@ -42,3 +44,10 @@ def utcnow() -> datetime:
 def utcnow_iso_str() -> str:
     """Get ISO formatted timezone-aware string for _now_."""
     return utcnow().isoformat()
+
+
+def json_encoder(obj: Any):
+    if isinstance(obj, statemachine.State):
+        return obj.name
+
+    return obj

--- a/dapp_runner/_util.py
+++ b/dapp_runner/_util.py
@@ -37,3 +37,8 @@ def _print_env_info(golem: Golem):
 def utcnow() -> datetime:
     """Get a timezone-aware datetime for _now_."""
     return datetime.now(tz=timezone.utc)
+
+
+def utcnow_iso_str() -> str:
+    """Get ISO formatted timezone-aware string for _now_."""
+    return utcnow().isoformat()

--- a/dapp_runner/_util.py
+++ b/dapp_runner/_util.py
@@ -47,6 +47,8 @@ def utcnow_iso_str() -> str:
 
 
 def json_encoder(obj: Any):
+    """Handle additional object types for `json.dump*` encoding."""
+
     if isinstance(obj, statemachine.State):
         return obj.name
 

--- a/dapp_runner/runner/__init__.py
+++ b/dapp_runner/runner/__init__.py
@@ -10,7 +10,7 @@ import traceback
 from typing import TextIO, Optional
 
 from dapp_runner.descriptor import Config, DappDescriptor, DescriptorError
-from dapp_runner._util import _print_env_info, utcnow
+from dapp_runner._util import _print_env_info, utcnow, json_encoder
 
 from .runner import Runner
 from .error import RunnerError
@@ -50,7 +50,9 @@ async def _run_app(
 
     await r.start()
     streamer = RunnerStreamer()
-    streamer.register_stream(r.state_queue, state_f, lambda msg: json.dumps(msg))
+    streamer.register_stream(
+        r.state_queue, state_f, lambda msg: json.dumps(msg, default=json_encoder)
+    )
     streamer.register_stream(r.data_queue, data_f, lambda msg: json.dumps(msg))
     if commands_f:
         streamer.add_task(
@@ -59,7 +61,9 @@ async def _run_app(
 
     if not silent:
         streamer.register_stream(
-            r.state_queue, sys.stdout, lambda msg: cyan(json.dumps(msg))
+            r.state_queue,
+            sys.stdout,
+            lambda msg: cyan(json.dumps(msg, default=json_encoder)),
         )
         streamer.register_stream(
             r.data_queue, sys.stdout, lambda msg: magenta(json.dumps(msg))

--- a/dapp_runner/runner/runner.py
+++ b/dapp_runner/runner/runner.py
@@ -50,7 +50,7 @@ class Runner:
     _networks: Dict[str, Network]
     _tasks: List[asyncio.Task]
     _startup_finished: bool
-    _desired_app_state: ServiceState
+    _desired_app_state: ServiceState  # TODO: Introduce ApplicationState instead of reusing ServiceState
 
     data_queue: asyncio.Queue
     state_queue: asyncio.Queue
@@ -276,7 +276,7 @@ class Runner:
             }
         )
 
-    # FIXME: Usage of @staticmethod is only for sake of unittests - to be removed
+    # FIXME: #79 should remove forced staticmethod
     @staticmethod
     def _get_app_state_from_nodes(
         dapp_node_count: int,

--- a/dapp_runner/runner/runner.py
+++ b/dapp_runner/runner/runner.py
@@ -3,7 +3,7 @@ import asyncio
 from dataclasses import asdict
 from datetime import datetime
 import logging
-from typing import Optional, Dict, List, Final, Set
+from typing import Optional, Dict, List, Final
 
 from yapapi import Golem
 from yapapi.contrib.service.http_proxy import LocalHttpProxy
@@ -182,7 +182,8 @@ class Runner:
         # broadcast current pending state, as we're getting ready to start services
         self._emit_update_to_state_queue()
 
-        # explicitly mark that we ultimately want app in "running" state, marking app into "starting" sequence.
+        # explicitly mark that we ultimately want app in "running" state,
+        #  marking app into "starting" sequence.
         self._desired_app_state = ServiceState.running
 
         await self.golem.start()
@@ -262,7 +263,7 @@ class Runner:
             self._emit_update_to_state_queue()
 
     def _emit_update_to_state_queue(self) -> None:
-        """Emit message with full state update to state queue"""
+        """Emit message with full state update to state queue."""
 
         nodes_states = self.dapp_state
 

--- a/dapp_runner/runner/runner.py
+++ b/dapp_runner/runner/runner.py
@@ -50,7 +50,9 @@ class Runner:
     _networks: Dict[str, Network]
     _tasks: List[asyncio.Task]
     _startup_finished: bool
-    _desired_app_state: ServiceState  # TODO: Introduce ApplicationState instead of reusing ServiceState
+
+    # TODO: Introduce ApplicationState instead of reusing ServiceState
+    _desired_app_state: ServiceState
 
     data_queue: asyncio.Queue
     state_queue: asyncio.Queue

--- a/dapp_runner/runner/runner.py
+++ b/dapp_runner/runner/runner.py
@@ -258,29 +258,27 @@ class Runner:
             nodes_states = self.dapp_state
 
             # on a state change, we're publishing the state of the whole dapp
-            self.state_queue.put_nowait({
-                'nodes': nodes_states,
-                'app': self._get_app_state_from_nodes(nodes_states),
-                'timestamp': utcnow_iso_str(),
-            })
+            self.state_queue.put_nowait(
+                {
+                    "nodes": nodes_states,
+                    "app": self._get_app_state_from_nodes(nodes_states),
+                    "timestamp": utcnow_iso_str(),
+                }
+            )
 
     def _get_app_state_from_nodes(self, nodes_states: Dict) -> str:
         """Return general application state based on all instances states."""
 
         # Collect nested node states into simple unique collection of state values
         all_states: Set[str] = set(
-            state
-            for node in nodes_states.values()
-            for state in node.values()
+            state for node in nodes_states.values() for state in node.values()
         )
 
         # If we want dapp to be running handle other states as starting
         if self._desired_app_state == ServiceState.running:
             # Check node-to-state parity because of node dependency,
             #  states gradually rolls out
-            if (
-                {self._desired_app_state.name} == all_states
-                and
+            if ({self._desired_app_state.name} == all_states) and (
                 len(nodes_states) == len(self.dapp.nodes)
             ):
                 return ServiceState.running.name

--- a/dapp_runner/runner/runner.py
+++ b/dapp_runner/runner/runner.py
@@ -215,7 +215,7 @@ class Runner:
 
         return {
             cluster_id: {
-                instance_index: instance.state
+                str(instance_index): instance.state
                 for instance_index, instance in enumerate(cluster.instances)
             }
             for cluster_id, cluster in self.clusters.items()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ pytest = "^7.1"
 pytest-asyncio = "^0.18.3"
 pytest-cov = "^3.0.0"
 liccheck = "^0.7.2"
+pytest-mock = "^3.10.0"
 
 [tool.poetry.scripts]
 dapp-runner = "dapp_runner.__main__:_cli"
@@ -83,7 +84,7 @@ unittest = "pytest --cov --cov-report html --cov-report term -sv tests/unit"
 test = ["unittest", "check"]
 
 [tool.pytest.ini_options]
-asyncio_mode= "auto"
+asyncio_mode = "auto"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -41,6 +41,7 @@ def test_utils():
 
 @pytest.fixture(scope="session")
 def event_loop():
+    """Make async fixtures use same event loop."""
     try:
         loop = asyncio.get_running_loop()
     except RuntimeError:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,4 +1,6 @@
 """Pytest configuration file containing the utilities for Dapp Runner tests."""
+import asyncio
+
 import pytest
 
 
@@ -35,3 +37,15 @@ class Utils:
 def test_utils():
     """Pytest fixture that exposes the Utils class."""
     return Utils
+
+
+@pytest.fixture(scope="session")
+def event_loop():
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+
+    yield loop
+
+    loop.close()

--- a/tests/unit/runner/test_runner.py
+++ b/tests/unit/runner/test_runner.py
@@ -99,7 +99,7 @@ async def test_runner_app_state_pending():
     """Test app state reporting at initial state of Runner."""
     dapp_node_count = 2
     desired_app_state = ServiceState.pending
-    nodes_states: Dict[str, Dict[str, ServiceState]] = {}
+    nodes_states: Dict[str, Dict[int, ServiceState]] = {}
 
     assert (
         Runner._get_app_state_from_nodes(
@@ -112,26 +112,26 @@ async def test_runner_app_state_pending():
 @pytest.mark.parametrize(
     "nodes_states",
     (
-        {"foo": {"0": ServiceState.pending}},
-        {"foo": {"0": ServiceState.starting}},
-        {"foo": {"0": ServiceState.running}},
-        {"foo": {"0": ServiceState.stopping}},
-        {"foo": {"0": ServiceState.terminated}},
+        {"foo": {0: ServiceState.pending}},
+        {"foo": {0: ServiceState.starting}},
+        {"foo": {0: ServiceState.running}},
+        {"foo": {0: ServiceState.stopping}},
+        {"foo": {0: ServiceState.terminated}},
         {
-            "foo": {"0": ServiceState.starting},
-            "bar": {"0": ServiceState.starting},
+            "foo": {0: ServiceState.starting},
+            "bar": {0: ServiceState.starting},
         },
         {
-            "foo": {"0": ServiceState.stopping},
-            "bar": {"0": ServiceState.stopping},
+            "foo": {0: ServiceState.stopping},
+            "bar": {0: ServiceState.stopping},
         },
         {
-            "foo": {"0": ServiceState.terminated},
-            "bar": {"0": ServiceState.terminated},
+            "foo": {0: ServiceState.terminated},
+            "bar": {0: ServiceState.terminated},
         },
         {
-            "foo": {"0": ServiceState.running},
-            "bar": {"0": ServiceState.terminated},
+            "foo": {0: ServiceState.running},
+            "bar": {0: ServiceState.terminated},
         },
     ),
 )
@@ -151,25 +151,25 @@ async def test_runner_app_state_starting(nodes_states):
 @pytest.mark.parametrize(
     "nodes_states",
     (
-        {"foo": {"0": ServiceState.pending}},
-        {"foo": {"0": ServiceState.starting}},
-        {"foo": {"0": ServiceState.running}},
-        {"foo": {"0": ServiceState.stopping}},
+        {"foo": {0: ServiceState.pending}},
+        {"foo": {0: ServiceState.starting}},
+        {"foo": {0: ServiceState.running}},
+        {"foo": {0: ServiceState.stopping}},
         {
-            "foo": {"0": ServiceState.starting},
-            "bar": {"0": ServiceState.starting},
+            "foo": {0: ServiceState.starting},
+            "bar": {0: ServiceState.starting},
         },
         {
-            "foo": {"0": ServiceState.stopping},
-            "bar": {"0": ServiceState.stopping},
+            "foo": {0: ServiceState.stopping},
+            "bar": {0: ServiceState.stopping},
         },
         {
-            "foo": {"0": ServiceState.running},
-            "bar": {"0": ServiceState.running},
+            "foo": {0: ServiceState.running},
+            "bar": {0: ServiceState.running},
         },
         {
-            "foo": {"0": ServiceState.running},
-            "bar": {"0": ServiceState.terminated},
+            "foo": {0: ServiceState.running},
+            "bar": {0: ServiceState.terminated},
         },
     ),
 )
@@ -191,8 +191,8 @@ async def test_runner_app_state_running():
     dapp_node_count = 2
     desired_app_state = ServiceState.running
     nodes_states = {
-        "foo": {"0": ServiceState.running},
-        "bar": {"0": ServiceState.running},
+        "foo": {0: ServiceState.running},
+        "bar": {0: ServiceState.running},
     }
 
     assert (
@@ -208,10 +208,10 @@ async def test_runner_app_state_running():
 @pytest.mark.parametrize(
     "nodes_states",
     (
-        {"foo": {"0": ServiceState.terminated}},
+        {"foo": {0: ServiceState.terminated}},
         {
-            "foo": {"0": ServiceState.terminated},
-            "bar": {"0": ServiceState.terminated},
+            "foo": {0: ServiceState.terminated},
+            "bar": {0: ServiceState.terminated},
         },
     ),
 )

--- a/tests/unit/runner/test_runner.py
+++ b/tests/unit/runner/test_runner.py
@@ -80,7 +80,7 @@ def runner(runner_config, dapp_descriptor, mocker):
     return runner
 
 
-@pytest.mark.skip("needs properly mocked `yapapi.Golem`")
+@pytest.mark.skip("needs properly mocked `yapapi.Golem` from #79")
 async def test_runner_desired_state(runner):
     """Test to check if desired app state is properly managed with app lifetime."""
     # TODO: Any way to avoid using non-public api?

--- a/tests/unit/runner/test_runner.py
+++ b/tests/unit/runner/test_runner.py
@@ -1,5 +1,7 @@
 """Tests for `dapp_runner.runner`."""
 from datetime import datetime, timezone, timedelta
+from typing import Dict
+
 import pytest
 from unittest import mock
 
@@ -97,7 +99,7 @@ async def test_runner_app_state_pending():
     """Test app state reporting at initial state of Runner."""
     dapp_node_count = 2
     desired_app_state = ServiceState.pending
-    nodes_states = {}
+    nodes_states: Dict[str, Dict[str, ServiceState]] = {}
 
     assert (
         Runner._get_app_state_from_nodes(

--- a/tests/unit/runner/test_runner.py
+++ b/tests/unit/runner/test_runner.py
@@ -3,7 +3,11 @@ from datetime import datetime, timezone, timedelta
 import pytest
 from unittest import mock
 
-from dapp_runner.runner import _running_time_elapsed  # noqa
+from yapapi.services import ServiceState
+
+from dapp_runner.descriptor import Config, DappDescriptor
+from dapp_runner.descriptor.config import YagnaConfig, PaymentConfig
+from dapp_runner.runner import _running_time_elapsed, Runner  # noqa
 
 
 def _some_datetime(offset: int = 0):
@@ -24,3 +28,162 @@ def _some_datetime(offset: int = 0):
 def test_running_time_elapsed(time_started, max_running_time, expected):
     """Test the `_running_time_elapsed` function."""
     assert _running_time_elapsed(time_started, max_running_time) == expected
+
+
+@pytest.fixture
+def runner_config():
+    return Config(
+        yagna=YagnaConfig(
+            subnet_tag="public",
+        ),
+        payment=PaymentConfig(
+            budget=1,
+            driver="erc20",
+            network="rinkeby",
+        ),
+    )
+
+
+@pytest.fixture
+def dapp_descriptor():
+    return DappDescriptor(
+        payloads={},
+        nodes={},
+    )
+
+
+@pytest.fixture
+def runner(runner_config, dapp_descriptor, mocker):
+    # TODO: How to mock Golem inside of Runner?
+    runner = Runner(
+        config=runner_config,
+        dapp=dapp_descriptor,
+    )
+
+    # Naive simplification of two nodes
+    mocker.patch.object(
+        runner.dapp,
+        "nodes",
+        {
+            "foo": None,
+            "bar": None,
+        },
+    )
+
+    return runner
+
+
+async def test_runner_desired_state(runner):
+    # TODO: Any way to avoid using non-public api?
+    assert runner._desired_app_state == ServiceState.pending
+
+    await runner.start()
+
+    assert runner._desired_app_state == ServiceState.running
+
+    await runner.stop()
+
+    assert runner._desired_app_state == ServiceState.terminated
+
+
+async def test_runner_app_state_pending(runner):
+    assert runner._get_app_state_from_nodes({}) == ServiceState.pending.name
+
+
+@pytest.mark.parametrize(
+    "nodes_states",
+    (
+        {"foo": {"0": ServiceState.pending.name}},
+        {"foo": {"0": ServiceState.starting.name}},
+        {"foo": {"0": ServiceState.running.name}},
+        {"foo": {"0": ServiceState.stopping.name}},
+        {"foo": {"0": ServiceState.terminated.name}},
+        {
+            "foo": {"0": ServiceState.starting.name},
+            "bar": {"0": ServiceState.starting.name},
+        },
+        {
+            "foo": {"0": ServiceState.stopping.name},
+            "bar": {"0": ServiceState.stopping.name},
+        },
+        {
+            "foo": {"0": ServiceState.terminated.name},
+            "bar": {"0": ServiceState.terminated.name},
+        },
+        {
+            "foo": {"0": ServiceState.running.name},
+            "bar": {"0": ServiceState.terminated.name},
+        },
+    ),
+)
+async def test_runner_app_state_starting(runner, nodes_states):
+    await runner.start()
+
+    assert runner._get_app_state_from_nodes(nodes_states) == ServiceState.starting.name
+
+    await runner.stop()
+
+
+@pytest.mark.parametrize(
+    "nodes_states",
+    (
+        {"foo": {"0": ServiceState.pending.name}},
+        {"foo": {"0": ServiceState.starting.name}},
+        {"foo": {"0": ServiceState.running.name}},
+        {"foo": {"0": ServiceState.stopping.name}},
+        {
+            "foo": {"0": ServiceState.starting.name},
+            "bar": {"0": ServiceState.starting.name},
+        },
+        {
+            "foo": {"0": ServiceState.stopping.name},
+            "bar": {"0": ServiceState.stopping.name},
+        },
+        {
+            "foo": {"0": ServiceState.running.name},
+            "bar": {"0": ServiceState.running.name},
+        },
+        {
+            "foo": {"0": ServiceState.running.name},
+            "bar": {"0": ServiceState.terminated.name},
+        },
+    ),
+)
+async def test_runner_app_state_stopping(runner, nodes_states):
+    await runner.stop()
+
+    assert runner._get_app_state_from_nodes(nodes_states) == ServiceState.stopping.name
+
+
+async def test_runner_app_state_running(runner):
+    await runner.start()
+
+    assert (
+        runner._get_app_state_from_nodes(
+            {
+                "foo": {"0": ServiceState.running.name},
+                "bar": {"0": ServiceState.running.name},
+            }
+        )
+        == ServiceState.running.name
+    )
+
+    await runner.stop()
+
+
+@pytest.mark.parametrize(
+    "nodes_states",
+    (
+        {"foo": {"0": ServiceState.terminated.name}},
+        {
+            "foo": {"0": ServiceState.terminated.name},
+            "bar": {"0": ServiceState.terminated.name},
+        },
+    ),
+)
+async def test_runner_app_state_terminated(runner, nodes_states):
+    await runner.stop()
+
+    assert (
+        runner._get_app_state_from_nodes(nodes_states) == ServiceState.terminated.name
+    )

--- a/tests/unit/runner/test_runner.py
+++ b/tests/unit/runner/test_runner.py
@@ -32,6 +32,8 @@ def test_running_time_elapsed(time_started, max_running_time, expected):
 
 @pytest.fixture
 def runner_config():
+    """Naive minimal example to satisfy Runner instantiation."""
+
     return Config(
         yagna=YagnaConfig(
             subnet_tag="public",
@@ -46,6 +48,7 @@ def runner_config():
 
 @pytest.fixture
 def dapp_descriptor():
+    """Naive minimal example to satisfy Runner instantiation."""
     return DappDescriptor(
         payloads={},
         nodes={},
@@ -54,6 +57,8 @@ def dapp_descriptor():
 
 @pytest.fixture
 def runner(runner_config, dapp_descriptor, mocker):
+    """Mostly mocked out Runner instance."""
+
     # TODO: How to mock Golem inside of Runner?
     runner = Runner(
         config=runner_config,
@@ -75,6 +80,7 @@ def runner(runner_config, dapp_descriptor, mocker):
 
 @pytest.mark.skip("needs properly mocked `yapapi.Golem`")
 async def test_runner_desired_state(runner):
+    """Test to check if desired app state is properly managed with app lifetime."""
     # TODO: Any way to avoid using non-public api?
     assert runner._desired_app_state == ServiceState.pending
 
@@ -88,6 +94,7 @@ async def test_runner_desired_state(runner):
 
 
 async def test_runner_app_state_pending():
+    """Test app state reporting at initial state of Runner."""
     dapp_node_count = 2
     desired_app_state = ServiceState.pending
     nodes_states = {}
@@ -127,6 +134,7 @@ async def test_runner_app_state_pending():
     ),
 )
 async def test_runner_app_state_starting(nodes_states):
+    """Test app state reporting while Runner is starting its services."""
     dapp_node_count = 2
     desired_app_state = ServiceState.running
 
@@ -164,6 +172,7 @@ async def test_runner_app_state_starting(nodes_states):
     ),
 )
 async def test_runner_app_state_stopping(nodes_states):
+    """Test app state reporting while Runner is stopping its services."""
     dapp_node_count = 2
     desired_app_state = ServiceState.terminated
 
@@ -176,6 +185,7 @@ async def test_runner_app_state_stopping(nodes_states):
 
 
 async def test_runner_app_state_running():
+    """Test app state reporting while Runner have all services running."""
     dapp_node_count = 2
     desired_app_state = ServiceState.running
     nodes_states = {
@@ -204,6 +214,7 @@ async def test_runner_app_state_running():
     ),
 )
 async def test_runner_app_state_terminated(nodes_states):
+    """Test app state reporting while Runner have all services terminated."""
     dapp_node_count = 2
     desired_app_state = ServiceState.terminated
 

--- a/tests/unit/runner/test_service.py
+++ b/tests/unit/runner/test_service.py
@@ -25,7 +25,6 @@ def mock_work_context():  # noqa
     return WorkContext(Mock(), Mock(), Mock(), Mock())
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "init, expected_script",
     [
@@ -127,7 +126,6 @@ SOME_PAYLOAD: Final = Payload()
 SOME_NETWORK: Final = Network(Mock(), "192.168.0.1/24", "192.168.0.1")
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "descriptor, payloads, networks, base_class, expected_kwargs, error",
     (


### PR DESCRIPTION
What have changed:
- I found that runner fails to create directory of dapp on windows due to using `:` in directory name. Windows is not capable to contain `:` characters in directory names, so I've changed them to `_` - I hope that additional `_` in directory name would not break something external.
- State stream is now providing timestamp of event with ISO format and `Z` timezone.
- State stream is now providing generalized app state based on all states on nodes.

Example of state stream after the changes:

```
{"nodes": {"http": {"0": "pending"}}, "app": "pending", "timestamp": "2022-12-21T16:12:48.798413Z"}
{"nodes": {"http": {"0": "starting"}}, "app": "starting", "timestamp": "2022-12-21T16:12:50.900074Z"}
{"nodes": {"http": {"0": "running"}}, "app": "running", "timestamp": "2022-12-21T16:12:53.186371Z"}
{"nodes": {"http": {"0": "stopping"}}, "app": "stopping", "timestamp": "2022-12-21T16:13:19.289442Z"}
{"nodes": {"http": {"0": "terminated"}}, "app": "terminated", "timestamp": "2022-12-21T16:13:20.173458Z"}
```